### PR TITLE
Fix deprecated APIs and update MoonBit interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ tmp
 .cache
 node_modules
 _build/
+_build
 target

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ tmp
 .vscode
 .cache
 node_modules
+_build/
+target

--- a/src/examples/01-close/pkg.generated.mbti
+++ b/src/examples/01-close/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/01-close"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/02-openat/main.mbt
+++ b/src/examples/02-openat/main.mbt
@@ -1,5 +1,5 @@
 ///|
-typealias @native.CStr
+using @native {type CStr}
 
 ///|
 fn main {

--- a/src/examples/02-openat/pkg.generated.mbti
+++ b/src/examples/02-openat/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/02-openat"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/03-getcwd/pkg.generated.mbti
+++ b/src/examples/03-getcwd/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/03-getcwd"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/04-dup/pkg.generated.mbti
+++ b/src/examples/04-dup/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/04-dup"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/05-fputc/pkg.generated.mbti
+++ b/src/examples/05-fputc/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/05-fputc"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/06-mkdirat/pkg.generated.mbti
+++ b/src/examples/06-mkdirat/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/06-mkdirat"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/07-fputs/pkg.generated.mbti
+++ b/src/examples/07-fputs/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/07-fputs"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/08-fwrite/pkg.generated.mbti
+++ b/src/examples/08-fwrite/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/08-fwrite"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/09-fread/pkg.generated.mbti
+++ b/src/examples/09-fread/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/09-fread"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/10-ungetc-fgetc/pkg.generated.mbti
+++ b/src/examples/10-ungetc-fgetc/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/10-ungetc-fgetc"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/11-setvbuf/pkg.generated.mbti
+++ b/src/examples/11-setvbuf/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/11-setvbuf"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/12-file-mode/pkg.generated.mbti
+++ b/src/examples/12-file-mode/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/12-file-mode"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/13-write/pkg.generated.mbti
+++ b/src/examples/13-write/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/13-write"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/14-read/pkg.generated.mbti
+++ b/src/examples/14-read/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/14-read"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/15-dup2/pkg.generated.mbti
+++ b/src/examples/15-dup2/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/15-dup2"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/16-fdopen-fclose/pkg.generated.mbti
+++ b/src/examples/16-fdopen-fclose/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/16-fdopen-fclose"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/17-fflush/pkg.generated.mbti
+++ b/src/examples/17-fflush/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/17-fflush"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/18-faccessat/pkg.generated.mbti
+++ b/src/examples/18-faccessat/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/18-faccessat"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/19-fork/pkg.generated.mbti
+++ b/src/examples/19-fork/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/19-fork"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/20-fork-pid-ppid/pkg.generated.mbti
+++ b/src/examples/20-fork-pid-ppid/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/20-fork-pid-ppid"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/21-getgid-getegid-getuid-geteuid-getsid/pkg.generated.mbti
+++ b/src/examples/21-getgid-getegid-getuid-geteuid-getsid/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/21-getgid-getegid-getuid-geteuid-getsid"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/22-setgid-setegid-setuid-seteuid/pkg.generated.mbti
+++ b/src/examples/22-setgid-setegid-setuid-seteuid/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/22-setgid-setegid-setuid-seteuid"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/23-setsid/pkg.generated.mbti
+++ b/src/examples/23-setsid/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/23-setsid"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/24-getpgid-setpgid/pkg.generated.mbti
+++ b/src/examples/24-getpgid-setpgid/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/24-getpgid-setpgid"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/25-unlinkat/pkg.generated.mbti
+++ b/src/examples/25-unlinkat/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/25-unlinkat"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/26-linkat/pkg.generated.mbti
+++ b/src/examples/26-linkat/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/26-linkat"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/27-fchdir/pkg.generated.mbti
+++ b/src/examples/27-fchdir/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/27-fchdir"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/28-fchown/pkg.generated.mbti
+++ b/src/examples/28-fchown/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/28-fchown"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/29-fexecve/pkg.generated.mbti
+++ b/src/examples/29-fexecve/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/29-fexecve"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/30-fdatasync/pkg.generated.mbti
+++ b/src/examples/30-fdatasync/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/30-fdatasync"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/31-fsync/pkg.generated.mbti
+++ b/src/examples/31-fsync/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/31-fsync"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/32-ftruncate/pkg.generated.mbti
+++ b/src/examples/32-ftruncate/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/32-ftruncate"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/33-fpathconf/pkg.generated.mbti
+++ b/src/examples/33-fpathconf/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/33-fpathconf"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/34-sync/pkg.generated.mbti
+++ b/src/examples/34-sync/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/34-sync"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/35-pause/pkg.generated.mbti
+++ b/src/examples/35-pause/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/35-pause"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/36-sleep/pkg.generated.mbti
+++ b/src/examples/36-sleep/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/36-sleep"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/37-nice/pkg.generated.mbti
+++ b/src/examples/37-nice/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/37-nice"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/38-gethostname/pkg.generated.mbti
+++ b/src/examples/38-gethostname/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/38-gethostname"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/39-sethostname/pkg.generated.mbti
+++ b/src/examples/39-sethostname/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/39-sethostname"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/40-getgroups/pkg.generated.mbti
+++ b/src/examples/40-getgroups/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/40-getgroups"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/41-confstr/pkg.generated.mbti
+++ b/src/examples/41-confstr/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/41-confstr"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/42-ttyname_r/pkg.generated.mbti
+++ b/src/examples/42-ttyname_r/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/42-ttyname_r"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/43-isatty/pkg.generated.mbti
+++ b/src/examples/43-isatty/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/43-isatty"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/44-pipe/pkg.generated.mbti
+++ b/src/examples/44-pipe/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/44-pipe"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/45-lseek/pkg.generated.mbti
+++ b/src/examples/45-lseek/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/45-lseek"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/46-pread/pkg.generated.mbti
+++ b/src/examples/46-pread/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/46-pread"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/47-pwrite/pkg.generated.mbti
+++ b/src/examples/47-pwrite/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/47-pwrite"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/48-fchownat/pkg.generated.mbti
+++ b/src/examples/48-fchownat/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/48-fchownat"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/examples/49-errno/pkg.generated.mbti
+++ b/src/examples/49-errno/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/examples/49-errno"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/posix/bitor.mbt
+++ b/src/posix/bitor.mbt
@@ -1,9 +1,9 @@
 ///|
 pub impl BitOr for OpenFlag with lor(self, other) {
-  self.inner() | other.inner()
+  self.0 | other.0
 }
 
 ///|
 pub impl BitOr for Mode with lor(self, other) {
-  self.inner() | other.inner()
+  self.0 | other.0
 }

--- a/src/posix/dirent.mbt
+++ b/src/posix/dirent.mbt
@@ -2,5 +2,6 @@
 #external
 type DIR
 
-///| https://man7.org/linux/man-pages/man3/fdopendir.3p.html
+///|
+/// https://man7.org/linux/man-pages/man3/fdopendir.3p.html
 extern "c" fn fdopendir(fd : Fd) -> Ptr[DIR] = "moonbit_posix_fdopendir"

--- a/src/posix/errno_linux.mbt
+++ b/src/posix/errno_linux.mbt
@@ -1,401 +1,535 @@
-///| EPERM 1 Operation not permitted
+///|
+/// EPERM 1 Operation not permitted
 pub const EPERM = 1
 
-///| ENOENT 2 No such file or directory
+///|
+/// ENOENT 2 No such file or directory
 pub const ENOENT = 2
 
-///| ESRCH 3 No such process
+///|
+/// ESRCH 3 No such process
 pub const ESRCH = 3
 
-///| EINTR 4 Interrupted system call
+///|
+/// EINTR 4 Interrupted system call
 pub const EINTR = 4
 
-///| EIO 5 Input/output error
+///|
+/// EIO 5 Input/output error
 pub const EIO = 5
 
-///| ENXIO 6 No such device or address
+///|
+/// ENXIO 6 No such device or address
 pub const ENXIO = 6
 
-///| E2BIG 7 Argument list too long
+///|
+/// E2BIG 7 Argument list too long
 pub const E2BIG = 7
 
-///| ENOEXEC 8 Exec format error
+///|
+/// ENOEXEC 8 Exec format error
 pub const ENOEXEC = 8
 
-///| EBADF 9 Bad file descriptor
+///|
+/// EBADF 9 Bad file descriptor
 pub const EBADF = 9
 
-///| ECHILD 10 No child processes
+///|
+/// ECHILD 10 No child processes
 pub const ECHILD = 10
 
-///| EAGAIN 11 Resource temporarily unavailable
+///|
+/// EAGAIN 11 Resource temporarily unavailable
 pub const EAGAIN = 11
 
-///| ENOMEM 12 Cannot allocate memory
+///|
+/// ENOMEM 12 Cannot allocate memory
 pub const ENOMEM = 12
 
-///| EACCES 13 Permission denied
+///|
+/// EACCES 13 Permission denied
 pub const EACCES = 13
 
-///| EFAULT 14 Bad address
+///|
+/// EFAULT 14 Bad address
 pub const EFAULT = 14
 
-///| ENOTBLK 15 Block device required
+///|
+/// ENOTBLK 15 Block device required
 pub const ENOTBLK = 15
 
-///| EBUSY 16 Device or resource busy
+///|
+/// EBUSY 16 Device or resource busy
 pub const EBUSY = 16
 
-///| EEXIST 17 File exists
+///|
+/// EEXIST 17 File exists
 pub const EEXIST = 17
 
-///| EXDEV 18 Invalid cross-device link
+///|
+/// EXDEV 18 Invalid cross-device link
 pub const EXDEV = 18
 
-///| ENODEV 19 No such device
+///|
+/// ENODEV 19 No such device
 pub const ENODEV = 19
 
-///| ENOTDIR 20 Not a directory
+///|
+/// ENOTDIR 20 Not a directory
 pub const ENOTDIR = 20
 
-///| EISDIR 21 Is a directory
+///|
+/// EISDIR 21 Is a directory
 pub const EISDIR = 21
 
-///| EINVAL 22 Invalid argument
+///|
+/// EINVAL 22 Invalid argument
 pub const EINVAL = 22
 
-///| ENFILE 23 Too many open files in system
+///|
+/// ENFILE 23 Too many open files in system
 pub const ENFILE = 23
 
-///| EMFILE 24 Too many open files
+///|
+/// EMFILE 24 Too many open files
 pub const EMFILE = 24
 
-///| ENOTTY 25 Inappropriate ioctl for device
+///|
+/// ENOTTY 25 Inappropriate ioctl for device
 pub const ENOTTY = 25
 
-///| ETXTBSY 26 Text file busy
+///|
+/// ETXTBSY 26 Text file busy
 pub const ETXTBSY = 26
 
-///| EFBIG 27 File too large
+///|
+/// EFBIG 27 File too large
 pub const EFBIG = 27
 
-///| ENOSPC 28 No space left on device
+///|
+/// ENOSPC 28 No space left on device
 pub const ENOSPC = 28
 
-///| ESPIPE 29 Illegal seek
+///|
+/// ESPIPE 29 Illegal seek
 pub const ESPIPE = 29
 
-///| EROFS 30 Read-only file system
+///|
+/// EROFS 30 Read-only file system
 pub const EROFS = 30
 
-///| EMLINK 31 Too many links
+///|
+/// EMLINK 31 Too many links
 pub const EMLINK = 31
 
-///| EPIPE 32 Broken pipe
+///|
+/// EPIPE 32 Broken pipe
 pub const EPIPE = 32
 
-///| EDOM 33 Numerical argument out of domain
+///|
+/// EDOM 33 Numerical argument out of domain
 pub const EDOM = 33
 
-///| ERANGE 34 Numerical result out of range
+///|
+/// ERANGE 34 Numerical result out of range
 pub const ERANGE = 34
 
-///| EDEADLK 35 Resource deadlock avoided
+///|
+/// EDEADLK 35 Resource deadlock avoided
 pub const EDEADLK = 35
 
-///| ENAMETOOLONG 36 File name too long
+///|
+/// ENAMETOOLONG 36 File name too long
 pub const ENAMETOOLONG = 36
 
-///| ENOLCK 37 No locks available
+///|
+/// ENOLCK 37 No locks available
 pub const ENOLCK = 37
 
-///| ENOSYS 38 Function not implemented
+///|
+/// ENOSYS 38 Function not implemented
 pub const ENOSYS = 38
 
-///| ENOTEMPTY 39 Directory not empty
+///|
+/// ENOTEMPTY 39 Directory not empty
 pub const ENOTEMPTY = 39
 
-///| ELOOP 40 Too many levels of symbolic links
+///|
+/// ELOOP 40 Too many levels of symbolic links
 pub const ELOOP = 40
 
-///| EWOULDBLOCK 11 Resource temporarily unavailable
+///|
+/// EWOULDBLOCK 11 Resource temporarily unavailable
 pub const EWOULDBLOCK = 11
 
-///| ENOMSG 42 No message of desired type
+///|
+/// ENOMSG 42 No message of desired type
 pub const ENOMSG = 42
 
-///| EIDRM 43 Identifier removed
+///|
+/// EIDRM 43 Identifier removed
 pub const EIDRM = 43
 
-///| ECHRNG 44 Channel number out of range
+///|
+/// ECHRNG 44 Channel number out of range
 pub const ECHRNG = 44
 
-///| EL2NSYNC 45 Level 2 not synchronized
+///|
+/// EL2NSYNC 45 Level 2 not synchronized
 pub const EL2NSYNC = 45
 
-///| EL3HLT 46 Level 3 halted
+///|
+/// EL3HLT 46 Level 3 halted
 pub const EL3HLT = 46
 
-///| EL3RST 47 Level 3 reset
+///|
+/// EL3RST 47 Level 3 reset
 pub const EL3RST = 47
 
-///| ELNRNG 48 Link number out of range
+///|
+/// ELNRNG 48 Link number out of range
 pub const ELNRNG = 48
 
-///| EUNATCH 49 Protocol driver not attached
+///|
+/// EUNATCH 49 Protocol driver not attached
 pub const EUNATCH = 49
 
-///| ENOCSI 50 No CSI structure available
+///|
+/// ENOCSI 50 No CSI structure available
 pub const ENOCSI = 50
 
-///| EL2HLT 51 Level 2 halted
+///|
+/// EL2HLT 51 Level 2 halted
 pub const EL2HLT = 51
 
-///| EBADE 52 Invalid exchange
+///|
+/// EBADE 52 Invalid exchange
 pub const EBADE = 52
 
-///| EBADR 53 Invalid request descriptor
+///|
+/// EBADR 53 Invalid request descriptor
 pub const EBADR = 53
 
-///| EXFULL 54 Exchange full
+///|
+/// EXFULL 54 Exchange full
 pub const EXFULL = 54
 
-///| ENOANO 55 No anode
+///|
+/// ENOANO 55 No anode
 pub const ENOANO = 55
 
-///| EBADRQC 56 Invalid request code
+///|
+/// EBADRQC 56 Invalid request code
 pub const EBADRQC = 56
 
-///| EBADSLT 57 Invalid slot
+///|
+/// EBADSLT 57 Invalid slot
 pub const EBADSLT = 57
 
-///| EDEADLOCK 35 Resource deadlock avoided
+///|
+/// EDEADLOCK 35 Resource deadlock avoided
 pub const EDEADLOCK = 35
 
-///| EBFONT 59 Bad font file format
+///|
+/// EBFONT 59 Bad font file format
 pub const EBFONT = 59
 
-///| ENOSTR 60 Device not a stream
+///|
+/// ENOSTR 60 Device not a stream
 pub const ENOSTR = 60
 
-///| ENODATA 61 No data available
+///|
+/// ENODATA 61 No data available
 pub const ENODATA = 61
 
-///| ETIME 62 Timer expired
+///|
+/// ETIME 62 Timer expired
 pub const ETIME = 62
 
-///| ENOSR 63 Out of streams resources
+///|
+/// ENOSR 63 Out of streams resources
 pub const ENOSR = 63
 
-///| ENONET 64 Machine is not on the network
+///|
+/// ENONET 64 Machine is not on the network
 pub const ENONET = 64
 
-///| ENOPKG 65 Package not installed
+///|
+/// ENOPKG 65 Package not installed
 pub const ENOPKG = 65
 
-///| EREMOTE 66 Object is remote
+///|
+/// EREMOTE 66 Object is remote
 pub const EREMOTE = 66
 
-///| ENOLINK 67 Link has been severed
+///|
+/// ENOLINK 67 Link has been severed
 pub const ENOLINK = 67
 
-///| EADV 68 Advertise error
+///|
+/// EADV 68 Advertise error
 pub const EADV = 68
 
-///| ESRMNT 69 Srmount error
+///|
+/// ESRMNT 69 Srmount error
 pub const ESRMNT = 69
 
-///| ECOMM 70 Communication error on send
+///|
+/// ECOMM 70 Communication error on send
 pub const ECOMM = 70
 
-///| EPROTO 71 Protocol error
+///|
+/// EPROTO 71 Protocol error
 pub const EPROTO = 71
 
-///| EMULTIHOP 72 Multihop attempted
+///|
+/// EMULTIHOP 72 Multihop attempted
 pub const EMULTIHOP = 72
 
-///| EDOTDOT 73 RFS specific error
+///|
+/// EDOTDOT 73 RFS specific error
 pub const EDOTDOT = 73
 
-///| EBADMSG 74 Bad message
+///|
+/// EBADMSG 74 Bad message
 pub const EBADMSG = 74
 
-///| EOVERFLOW 75 Value too large for defined data type
+///|
+/// EOVERFLOW 75 Value too large for defined data type
 pub const EOVERFLOW = 75
 
-///| ENOTUNIQ 76 Name not unique on network
+///|
+/// ENOTUNIQ 76 Name not unique on network
 pub const ENOTUNIQ = 76
 
-///| EBADFD 77 File descriptor in bad state
+///|
+/// EBADFD 77 File descriptor in bad state
 pub const EBADFD = 77
 
-///| EREMCHG 78 Remote address changed
+///|
+/// EREMCHG 78 Remote address changed
 pub const EREMCHG = 78
 
-///| ELIBACC 79 Can not access a needed shared library
+///|
+/// ELIBACC 79 Can not access a needed shared library
 pub const ELIBACC = 79
 
-///| ELIBBAD 80 Accessing a corrupted shared library
+///|
+/// ELIBBAD 80 Accessing a corrupted shared library
 pub const ELIBBAD = 80
 
-///| ELIBSCN 81 .lib section in a.out corrupted
+///|
+/// ELIBSCN 81 .lib section in a.out corrupted
 pub const ELIBSCN = 81
 
-///| ELIBMAX 82 Attempting to link in too many shared libraries
+///|
+/// ELIBMAX 82 Attempting to link in too many shared libraries
 pub const ELIBMAX = 82
 
-///| ELIBEXEC 83 Cannot exec a shared library directly
+///|
+/// ELIBEXEC 83 Cannot exec a shared library directly
 pub const ELIBEXEC = 83
 
-///| EILSEQ 84 Invalid or incomplete multibyte or wide character
+///|
+/// EILSEQ 84 Invalid or incomplete multibyte or wide character
 pub const EILSEQ = 84
 
-///| ERESTART 85 Interrupted system call should be restarted
+///|
+/// ERESTART 85 Interrupted system call should be restarted
 pub const ERESTART = 85
 
-///| ESTRPIPE 86 Streams pipe error
+///|
+/// ESTRPIPE 86 Streams pipe error
 pub const ESTRPIPE = 86
 
-///| EUSERS 87 Too many users
+///|
+/// EUSERS 87 Too many users
 pub const EUSERS = 87
 
-///| ENOTSOCK 88 Socket operation on non-socket
+///|
+/// ENOTSOCK 88 Socket operation on non-socket
 pub const ENOTSOCK = 88
 
-///| EDESTADDRREQ 89 Destination address required
+///|
+/// EDESTADDRREQ 89 Destination address required
 pub const EDESTADDRREQ = 89
 
-///| EMSGSIZE 90 Message too long
+///|
+/// EMSGSIZE 90 Message too long
 pub const EMSGSIZE = 90
 
-///| EPROTOTYPE 91 Protocol wrong type for socket
+///|
+/// EPROTOTYPE 91 Protocol wrong type for socket
 pub const EPROTOTYPE = 91
 
-///| ENOPROTOOPT 92 Protocol not available
+///|
+/// ENOPROTOOPT 92 Protocol not available
 pub const ENOPROTOOPT = 92
 
-///| EPROTONOSUPPORT 93 Protocol not supported
+///|
+/// EPROTONOSUPPORT 93 Protocol not supported
 pub const EPROTONOSUPPORT = 93
 
-///| ESOCKTNOSUPPORT 94 Socket type not supported
+///|
+/// ESOCKTNOSUPPORT 94 Socket type not supported
 pub const ESOCKTNOSUPPORT = 94
 
-///| EOPNOTSUPP 95 Operation not supported
+///|
+/// EOPNOTSUPP 95 Operation not supported
 pub const EOPNOTSUPP = 95
 
-///| EPFNOSUPPORT 96 Protocol family not supported
+///|
+/// EPFNOSUPPORT 96 Protocol family not supported
 pub const EPFNOSUPPORT = 96
 
-///| EAFNOSUPPORT 97 Address family not supported by protocol
+///|
+/// EAFNOSUPPORT 97 Address family not supported by protocol
 pub const EAFNOSUPPORT = 97
 
-///| EADDRINUSE 98 Address already in use
+///|
+/// EADDRINUSE 98 Address already in use
 pub const EADDRINUSE = 98
 
-///| EADDRNOTAVAIL 99 Cannot assign requested address
+///|
+/// EADDRNOTAVAIL 99 Cannot assign requested address
 pub const EADDRNOTAVAIL = 99
 
-///| ENETDOWN 100 Network is down
+///|
+/// ENETDOWN 100 Network is down
 pub const ENETDOWN = 100
 
-///| ENETUNREACH 101 Network is unreachable
+///|
+/// ENETUNREACH 101 Network is unreachable
 pub const ENETUNREACH = 101
 
-///| ENETRESET 102 Network dropped connection on reset
+///|
+/// ENETRESET 102 Network dropped connection on reset
 pub const ENETRESET = 102
 
-///| ECONNABORTED 103 Software caused connection abort
+///|
+/// ECONNABORTED 103 Software caused connection abort
 pub const ECONNABORTED = 103
 
-///| ECONNRESET 104 Connection reset by peer
+///|
+/// ECONNRESET 104 Connection reset by peer
 pub const ECONNRESET = 104
 
-///| ENOBUFS 105 No buffer space available
+///|
+/// ENOBUFS 105 No buffer space available
 pub const ENOBUFS = 105
 
-///| EISCONN 106 Transport endpoint is already connected
+///|
+/// EISCONN 106 Transport endpoint is already connected
 pub const EISCONN = 106
 
-///| ENOTCONN 107 Transport endpoint is not connected
+///|
+/// ENOTCONN 107 Transport endpoint is not connected
 pub const ENOTCONN = 107
 
-///| ESHUTDOWN 108 Cannot send after transport endpoint shutdown
+///|
+/// ESHUTDOWN 108 Cannot send after transport endpoint shutdown
 pub const ESHUTDOWN = 108
 
-///| ETOOMANYREFS 109 Too many references: cannot splice
+///|
+/// ETOOMANYREFS 109 Too many references: cannot splice
 pub const ETOOMANYREFS = 109
 
-///| ETIMEDOUT 110 Connection timed out
+///|
+/// ETIMEDOUT 110 Connection timed out
 pub const ETIMEDOUT = 110
 
-///| ECONNREFUSED 111 Connection refused
+///|
+/// ECONNREFUSED 111 Connection refused
 pub const ECONNREFUSED = 111
 
-///| EHOSTDOWN 112 Host is down
+///|
+/// EHOSTDOWN 112 Host is down
 pub const EHOSTDOWN = 112
 
-///| EHOSTUNREACH 113 No route to host
+///|
+/// EHOSTUNREACH 113 No route to host
 pub const EHOSTUNREACH = 113
 
-///| EALREADY 114 Operation already in progress
+///|
+/// EALREADY 114 Operation already in progress
 pub const EALREADY = 114
 
-///| EINPROGRESS 115 Operation now in progress
+///|
+/// EINPROGRESS 115 Operation now in progress
 pub const EINPROGRESS = 115
 
-///| ESTALE 116 Stale file handle
+///|
+/// ESTALE 116 Stale file handle
 pub const ESTALE = 116
 
-///| EUCLEAN 117 Structure needs cleaning
+///|
+/// EUCLEAN 117 Structure needs cleaning
 pub const EUCLEAN = 117
 
-///| ENOTNAM 118 Not a XENIX named type file
+///|
+/// ENOTNAM 118 Not a XENIX named type file
 pub const ENOTNAM = 118
 
-///| ENAVAIL 119 No XENIX semaphores available
+///|
+/// ENAVAIL 119 No XENIX semaphores available
 pub const ENAVAIL = 119
 
-///| EISNAM 120 Is a named type file
+///|
+/// EISNAM 120 Is a named type file
 pub const EISNAM = 120
 
-///| EREMOTEIO 121 Remote I/O error
+///|
+/// EREMOTEIO 121 Remote I/O error
 pub const EREMOTEIO = 121
 
-///| EDQUOT 122 Disk quota exceeded
+///|
+/// EDQUOT 122 Disk quota exceeded
 pub const EDQUOT = 122
 
-///| ENOMEDIUM 123 No medium found
+///|
+/// ENOMEDIUM 123 No medium found
 pub const ENOMEDIUM = 123
 
-///| EMEDIUMTYPE 124 Wrong medium type
+///|
+/// EMEDIUMTYPE 124 Wrong medium type
 pub const EMEDIUMTYPE = 124
 
-///| ECANCELED 125 Operation canceled
+///|
+/// ECANCELED 125 Operation canceled
 pub const ECANCELED = 125
 
-///| ENOKEY 126 Required key not available
+///|
+/// ENOKEY 126 Required key not available
 pub const ENOKEY = 126
 
-///| EKEYEXPIRED 127 Key has expired
+///|
+/// EKEYEXPIRED 127 Key has expired
 pub const EKEYEXPIRED = 127
 
-///| EKEYREVOKED 128 Key has been revoked
+///|
+/// EKEYREVOKED 128 Key has been revoked
 pub const EKEYREVOKED = 128
 
-///| EKEYREJECTED 129 Key was rejected by service
+///|
+/// EKEYREJECTED 129 Key was rejected by service
 pub const EKEYREJECTED = 129
 
-///| EOWNERDEAD 130 Owner died
+///|
+/// EOWNERDEAD 130 Owner died
 pub const EOWNERDEAD = 130
 
-///| ENOTRECOVERABLE 131 State not recoverable
+///|
+/// ENOTRECOVERABLE 131 State not recoverable
 pub const ENOTRECOVERABLE = 131
 
-///| ERFKILL 132 Operation not possible due to RF-kill
+///|
+/// ERFKILL 132 Operation not possible due to RF-kill
 pub const ERFKILL = 132
 
-///| EHWPOISON 133 Memory page has hardware error
+///|
+/// EHWPOISON 133 Memory page has hardware error
 pub const EHWPOISON = 133
 
-///| ENOTSUP 95 Operation not supported
+///|
+/// ENOTSUP 95 Operation not supported
 pub const ENOTSUP = 95

--- a/src/posix/fcntl.mbt
+++ b/src/posix/fcntl.mbt
@@ -238,12 +238,13 @@ pub let f_unlck : FcntlCmd = _F_UNLCK()
 ///|
 pub let f_wrlck : FcntlCmd = _F_WRLCK()
 
-///| https://man7.org/linux/man-pages/man2/open.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/open.2.html
 pub extern "c" fn openat(
   dirfd : Fd,
   path : CStr,
   flags : OpenFlag,
-  mode : Mode
+  mode : Mode,
 ) -> Fd = "moonbit_posix_openat"
 
 ///|

--- a/src/posix/fcntl.mbt
+++ b/src/posix/fcntl.mbt
@@ -240,6 +240,7 @@ pub let f_wrlck : FcntlCmd = _F_WRLCK()
 
 ///|
 /// https://man7.org/linux/man-pages/man2/open.2.html
+#borrow(path)
 pub extern "c" fn openat(
   dirfd : Fd,
   path : CStr,

--- a/src/posix/imports.mbt
+++ b/src/posix/imports.mbt
@@ -1,11 +1,11 @@
 ///|
-pub typealias @native.CStr
+pub using @native {type CStr}
 
 ///|
-pub typealias @native.Ptr
+pub using @native {type Ptr}
 
 ///|
-pub typealias @native.ConstPtr
+pub using @native {type ConstPtr}
 
 ///|
-pub typealias @native.Rc
+pub using @native {type Rc}

--- a/src/posix/pkg.generated.mbti
+++ b/src/posix/pkg.generated.mbti
@@ -1,0 +1,1011 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/posix/posix"
+
+import(
+  "illusory0x0/native"
+)
+
+// Values
+pub const E2BIG : Int = 7
+
+pub const EACCES : Int = 13
+
+pub const EADDRINUSE : Int = 98
+
+pub const EADDRNOTAVAIL : Int = 99
+
+pub const EADV : Int = 68
+
+pub const EAFNOSUPPORT : Int = 97
+
+pub const EAGAIN : Int = 11
+
+pub const EALREADY : Int = 114
+
+pub const EBADE : Int = 52
+
+pub const EBADF : Int = 9
+
+pub const EBADFD : Int = 77
+
+pub const EBADMSG : Int = 74
+
+pub const EBADR : Int = 53
+
+pub const EBADRQC : Int = 56
+
+pub const EBADSLT : Int = 57
+
+pub const EBFONT : Int = 59
+
+pub const EBUSY : Int = 16
+
+pub const ECANCELED : Int = 125
+
+pub const ECHILD : Int = 10
+
+pub const ECHRNG : Int = 44
+
+pub const ECOMM : Int = 70
+
+pub const ECONNABORTED : Int = 103
+
+pub const ECONNREFUSED : Int = 111
+
+pub const ECONNRESET : Int = 104
+
+pub const EDEADLK : Int = 35
+
+pub const EDEADLOCK : Int = 35
+
+pub const EDESTADDRREQ : Int = 89
+
+pub const EDOM : Int = 33
+
+pub const EDOTDOT : Int = 73
+
+pub const EDQUOT : Int = 122
+
+pub const EEXIST : Int = 17
+
+pub const EFAULT : Int = 14
+
+pub const EFBIG : Int = 27
+
+pub const EHOSTDOWN : Int = 112
+
+pub const EHOSTUNREACH : Int = 113
+
+pub const EHWPOISON : Int = 133
+
+pub const EIDRM : Int = 43
+
+pub const EILSEQ : Int = 84
+
+pub const EINPROGRESS : Int = 115
+
+pub const EINTR : Int = 4
+
+pub const EINVAL : Int = 22
+
+pub const EIO : Int = 5
+
+pub const EISCONN : Int = 106
+
+pub const EISDIR : Int = 21
+
+pub const EISNAM : Int = 120
+
+pub const EKEYEXPIRED : Int = 127
+
+pub const EKEYREJECTED : Int = 129
+
+pub const EKEYREVOKED : Int = 128
+
+pub const EL2HLT : Int = 51
+
+pub const EL2NSYNC : Int = 45
+
+pub const EL3HLT : Int = 46
+
+pub const EL3RST : Int = 47
+
+pub const ELIBACC : Int = 79
+
+pub const ELIBBAD : Int = 80
+
+pub const ELIBEXEC : Int = 83
+
+pub const ELIBMAX : Int = 82
+
+pub const ELIBSCN : Int = 81
+
+pub const ELNRNG : Int = 48
+
+pub const ELOOP : Int = 40
+
+pub const EMEDIUMTYPE : Int = 124
+
+pub const EMFILE : Int = 24
+
+pub const EMLINK : Int = 31
+
+pub const EMSGSIZE : Int = 90
+
+pub const EMULTIHOP : Int = 72
+
+pub const ENAMETOOLONG : Int = 36
+
+pub const ENAVAIL : Int = 119
+
+pub const ENETDOWN : Int = 100
+
+pub const ENETRESET : Int = 102
+
+pub const ENETUNREACH : Int = 101
+
+pub const ENFILE : Int = 23
+
+pub const ENOANO : Int = 55
+
+pub const ENOBUFS : Int = 105
+
+pub const ENOCSI : Int = 50
+
+pub const ENODATA : Int = 61
+
+pub const ENODEV : Int = 19
+
+pub const ENOENT : Int = 2
+
+pub const ENOEXEC : Int = 8
+
+pub const ENOKEY : Int = 126
+
+pub const ENOLCK : Int = 37
+
+pub const ENOLINK : Int = 67
+
+pub const ENOMEDIUM : Int = 123
+
+pub const ENOMEM : Int = 12
+
+pub const ENOMSG : Int = 42
+
+pub const ENONET : Int = 64
+
+pub const ENOPKG : Int = 65
+
+pub const ENOPROTOOPT : Int = 92
+
+pub const ENOSPC : Int = 28
+
+pub const ENOSR : Int = 63
+
+pub const ENOSTR : Int = 60
+
+pub const ENOSYS : Int = 38
+
+pub const ENOTBLK : Int = 15
+
+pub const ENOTCONN : Int = 107
+
+pub const ENOTDIR : Int = 20
+
+pub const ENOTEMPTY : Int = 39
+
+pub const ENOTNAM : Int = 118
+
+pub const ENOTRECOVERABLE : Int = 131
+
+pub const ENOTSOCK : Int = 88
+
+pub const ENOTSUP : Int = 95
+
+pub const ENOTTY : Int = 25
+
+pub const ENOTUNIQ : Int = 76
+
+pub const ENXIO : Int = 6
+
+pub const EOPNOTSUPP : Int = 95
+
+pub const EOVERFLOW : Int = 75
+
+pub const EOWNERDEAD : Int = 130
+
+pub const EPERM : Int = 1
+
+pub const EPFNOSUPPORT : Int = 96
+
+pub const EPIPE : Int = 32
+
+pub const EPROTO : Int = 71
+
+pub const EPROTONOSUPPORT : Int = 93
+
+pub const EPROTOTYPE : Int = 91
+
+pub const ERANGE : Int = 34
+
+pub const EREMCHG : Int = 78
+
+pub const EREMOTE : Int = 66
+
+pub const EREMOTEIO : Int = 121
+
+pub const ERESTART : Int = 85
+
+pub const ERFKILL : Int = 132
+
+pub const EROFS : Int = 30
+
+pub const ESHUTDOWN : Int = 108
+
+pub const ESOCKTNOSUPPORT : Int = 94
+
+pub const ESPIPE : Int = 29
+
+pub const ESRCH : Int = 3
+
+pub const ESRMNT : Int = 69
+
+pub const ESTALE : Int = 116
+
+pub const ESTRPIPE : Int = 86
+
+pub const ETIME : Int = 62
+
+pub const ETIMEDOUT : Int = 110
+
+pub const ETOOMANYREFS : Int = 109
+
+pub const ETXTBSY : Int = 26
+
+pub const EUCLEAN : Int = 117
+
+pub const EUNATCH : Int = 49
+
+pub const EUSERS : Int = 87
+
+pub const EWOULDBLOCK : Int = 11
+
+pub const EXDEV : Int = 18
+
+pub const EXFULL : Int = 54
+
+pub let _cs_path : Int
+
+pub let _cs_posix_v6_ilp32_off32_cflags : Int
+
+pub let _cs_posix_v6_ilp32_off32_ldflags : Int
+
+pub let _cs_posix_v6_ilp32_off32_libs : Int
+
+pub let _cs_posix_v6_ilp32_offbig_cflags : Int
+
+pub let _cs_posix_v6_ilp32_offbig_ldflags : Int
+
+pub let _cs_posix_v6_ilp32_offbig_libs : Int
+
+pub let _cs_posix_v6_lp64_off64_cflags : Int
+
+pub let _cs_posix_v6_lp64_off64_ldflags : Int
+
+pub let _cs_posix_v6_lp64_off64_libs : Int
+
+pub let _cs_posix_v6_lpbig_offbig_cflags : Int
+
+pub let _cs_posix_v6_lpbig_offbig_ldflags : Int
+
+pub let _cs_posix_v6_lpbig_offbig_libs : Int
+
+pub let _cs_posix_v6_width_restricted_envs : Int
+
+pub let _cs_posix_v7_ilp32_off32_cflags : Int
+
+pub let _cs_posix_v7_ilp32_off32_ldflags : Int
+
+pub let _cs_posix_v7_ilp32_off32_libs : Int
+
+pub let _cs_posix_v7_ilp32_offbig_cflags : Int
+
+pub let _cs_posix_v7_ilp32_offbig_ldflags : Int
+
+pub let _cs_posix_v7_ilp32_offbig_libs : Int
+
+pub let _cs_posix_v7_lp64_off64_cflags : Int
+
+pub let _cs_posix_v7_lp64_off64_ldflags : Int
+
+pub let _cs_posix_v7_lp64_off64_libs : Int
+
+pub let _cs_posix_v7_lpbig_offbig_cflags : Int
+
+pub let _cs_posix_v7_lpbig_offbig_ldflags : Int
+
+pub let _cs_posix_v7_lpbig_offbig_libs : Int
+
+pub let _cs_posix_v7_width_restricted_envs : Int
+
+pub let _cs_v6_env : Int
+
+pub let _cs_v7_env : Int
+
+pub let _iofbf : BufMode
+
+pub let _iolbf : BufMode
+
+pub let _ionbf : BufMode
+
+pub let _pc_2_symlinks : Int
+
+pub let _pc_alloc_size_min : Int
+
+pub let _pc_async_io : Int
+
+pub let _pc_chown_restricted : Int
+
+pub let _pc_filesizebits : Int
+
+pub let _pc_link_max : Int
+
+pub let _pc_max_canon : Int
+
+pub let _pc_max_input : Int
+
+pub let _pc_name_max : Int
+
+pub let _pc_no_trunc : Int
+
+pub let _pc_path_max : Int
+
+pub let _pc_pipe_buf : Int
+
+pub let _pc_prio_io : Int
+
+pub let _pc_rec_incr_xfer_size : Int
+
+pub let _pc_rec_max_xfer_size : Int
+
+pub let _pc_rec_min_xfer_size : Int
+
+pub let _pc_rec_xfer_align : Int
+
+pub let _pc_symlink_max : Int
+
+pub let _pc_sync_io : Int
+
+pub let _pc_vdisable : Int
+
+pub let _sc_2_c_bind : Int
+
+pub let _sc_2_c_dev : Int
+
+pub let _sc_2_char_term : Int
+
+pub let _sc_2_fort_dev : Int
+
+pub let _sc_2_fort_run : Int
+
+pub let _sc_2_localedef : Int
+
+pub let _sc_2_pbs : Int
+
+pub let _sc_2_pbs_accounting : Int
+
+pub let _sc_2_pbs_checkpoint : Int
+
+pub let _sc_2_pbs_locate : Int
+
+pub let _sc_2_pbs_message : Int
+
+pub let _sc_2_pbs_track : Int
+
+pub let _sc_2_sw_dev : Int
+
+pub let _sc_2_upe : Int
+
+pub let _sc_2_version : Int
+
+pub let _sc_advisory_info : Int
+
+pub let _sc_aio_listio_max : Int
+
+pub let _sc_aio_max : Int
+
+pub let _sc_aio_prio_delta_max : Int
+
+pub let _sc_arg_max : Int
+
+pub let _sc_asynchronous_io : Int
+
+pub let _sc_atexit_max : Int
+
+pub let _sc_barriers : Int
+
+pub let _sc_bc_base_max : Int
+
+pub let _sc_bc_dim_max : Int
+
+pub let _sc_bc_scale_max : Int
+
+pub let _sc_bc_string_max : Int
+
+pub let _sc_child_max : Int
+
+pub let _sc_clk_tck : Int
+
+pub let _sc_clock_selection : Int
+
+pub let _sc_coll_weights_max : Int
+
+pub let _sc_cputime : Int
+
+pub let _sc_delaytimer_max : Int
+
+pub let _sc_expr_nest_max : Int
+
+pub let _sc_fsync : Int
+
+pub let _sc_getgr_r_size_max : Int
+
+pub let _sc_getpw_r_size_max : Int
+
+pub let _sc_host_name_max : Int
+
+pub let _sc_iov_max : Int
+
+pub let _sc_ipv6 : Int
+
+pub let _sc_job_control : Int
+
+pub let _sc_line_max : Int
+
+pub let _sc_login_name_max : Int
+
+pub let _sc_mapped_files : Int
+
+pub let _sc_memlock : Int
+
+pub let _sc_memlock_range : Int
+
+pub let _sc_memory_protection : Int
+
+pub let _sc_message_passing : Int
+
+pub let _sc_monotonic_clock : Int
+
+pub let _sc_mq_open_max : Int
+
+pub let _sc_mq_prio_max : Int
+
+pub let _sc_ngroups_max : Int
+
+pub let _sc_open_max : Int
+
+pub let _sc_page_size : Int
+
+pub let _sc_pagesize : Int
+
+pub let _sc_prioritized_io : Int
+
+pub let _sc_priority_scheduling : Int
+
+pub let _sc_raw_sockets : Int
+
+pub let _sc_re_dup_max : Int
+
+pub let _sc_reader_writer_locks : Int
+
+pub let _sc_realtime_signals : Int
+
+pub let _sc_regexp : Int
+
+pub let _sc_rtsig_max : Int
+
+pub let _sc_saved_ids : Int
+
+pub let _sc_sem_nsems_max : Int
+
+pub let _sc_sem_value_max : Int
+
+pub let _sc_semaphores : Int
+
+pub let _sc_shared_memory_objects : Int
+
+pub let _sc_shell : Int
+
+pub let _sc_sigqueue_max : Int
+
+pub let _sc_spawn : Int
+
+pub let _sc_spin_locks : Int
+
+pub let _sc_sporadic_server : Int
+
+pub let _sc_ss_repl_max : Int
+
+pub let _sc_stream_max : Int
+
+pub let _sc_symloop_max : Int
+
+pub let _sc_synchronized_io : Int
+
+pub let _sc_thread_attr_stackaddr : Int
+
+pub let _sc_thread_attr_stacksize : Int
+
+pub let _sc_thread_cputime : Int
+
+pub let _sc_thread_destructor_iterations : Int
+
+pub let _sc_thread_keys_max : Int
+
+pub let _sc_thread_prio_inherit : Int
+
+pub let _sc_thread_prio_protect : Int
+
+pub let _sc_thread_priority_scheduling : Int
+
+pub let _sc_thread_process_shared : Int
+
+pub let _sc_thread_robust_prio_inherit : Int
+
+pub let _sc_thread_robust_prio_protect : Int
+
+pub let _sc_thread_safe_functions : Int
+
+pub let _sc_thread_sporadic_server : Int
+
+pub let _sc_thread_stack_min : Int
+
+pub let _sc_thread_threads_max : Int
+
+pub let _sc_threads : Int
+
+pub let _sc_timeouts : Int
+
+pub let _sc_timer_max : Int
+
+pub let _sc_timers : Int
+
+pub let _sc_trace : Int
+
+pub let _sc_trace_event_filter : Int
+
+pub let _sc_trace_event_name_max : Int
+
+pub let _sc_trace_inherit : Int
+
+pub let _sc_trace_log : Int
+
+pub let _sc_trace_name_max : Int
+
+pub let _sc_trace_sys_max : Int
+
+pub let _sc_trace_user_event_max : Int
+
+pub let _sc_tty_name_max : Int
+
+pub let _sc_typed_memory_objects : Int
+
+pub let _sc_tzname_max : Int
+
+pub let _sc_v6_ilp32_off32 : Int
+
+pub let _sc_v6_ilp32_offbig : Int
+
+pub let _sc_v6_lp64_off64 : Int
+
+pub let _sc_v6_lpbig_offbig : Int
+
+pub let _sc_v7_ilp32_off32 : Int
+
+pub let _sc_v7_ilp32_offbig : Int
+
+pub let _sc_v7_lp64_off64 : Int
+
+pub let _sc_v7_lpbig_offbig : Int
+
+pub let _sc_version : Int
+
+pub let _sc_xopen_crypt : Int
+
+pub let _sc_xopen_enh_i18n : Int
+
+pub let _sc_xopen_realtime : Int
+
+pub let _sc_xopen_realtime_threads : Int
+
+pub let _sc_xopen_shm : Int
+
+pub let _sc_xopen_streams : Int
+
+pub let _sc_xopen_unix : Int
+
+pub let _sc_xopen_version : Int
+
+pub let at_eaccess : AtFlag
+
+pub let at_fdcwd : Fd
+
+pub let at_removedir : AtFlag
+
+pub let at_symlink_follow : AtFlag
+
+pub let at_symlink_nofollow : AtFlag
+
+pub let bufsiz : UInt64
+
+pub fn close(Fd) -> Rslt
+
+pub fn confstr(Int, @native.Ptr[Byte], UInt64) -> UInt64
+
+pub let directory_default_mode : Mode
+
+pub fn dup(Fd) -> Fd
+
+pub fn dup2(Fd, Fd) -> Fd
+
+pub let eof : FRslt
+
+pub let f_dupfd : FcntlCmd
+
+pub let f_dupfd_cloexec : FcntlCmd
+
+pub let f_getfd : FcntlCmd
+
+pub let f_getfl : FcntlCmd
+
+pub let f_getlk : FcntlCmd
+
+pub let f_getown : FcntlCmd
+
+pub let f_ok : AccessMode
+
+pub let f_rdlck : FcntlCmd
+
+pub let f_setfd : FcntlCmd
+
+pub let f_setfl : FcntlCmd
+
+pub let f_setlk : FcntlCmd
+
+pub let f_setlkw : FcntlCmd
+
+pub let f_setown : FcntlCmd
+
+pub let f_unlck : FcntlCmd
+
+pub let f_wrlck : FcntlCmd
+
+pub fn faccessat(Fd, @native.CStr, AccessMode, AtFlag) -> Rslt
+
+pub fn fchdir(Fd) -> Rslt
+
+pub fn fchown(Fd, Uid, Gid) -> Rslt
+
+pub fn fchownat(Fd, @native.CStr, Uid, Gid, AtFlag) -> Rslt
+
+pub fn fclose(@native.Ptr[FILE]) -> FRslt
+
+pub let fd_cloexec : FcntlCmd
+
+pub fn fdatasync(Fd) -> Rslt
+
+pub fn fdopen(Fd, @native.CStr) -> @native.Ptr[FILE]
+
+pub fn fexecve(Fd, @native.ConstPtr[@native.CStr], @native.ConstPtr[@native.CStr]) -> Rslt
+
+pub fn fflush(@native.Ptr[FILE]) -> FRslt
+
+pub fn fgetc(@native.Ptr[FILE]) -> FRslt
+
+pub fn fgets(@native.Ptr[Byte], Int, @native.Ptr[FILE]) -> @native.Ptr[Byte]
+
+pub let file_default_mode : Mode
+
+pub fn fork() -> Pid
+
+pub fn fpathconf(Fd, Int) -> Int64
+
+pub fn fputc(Int, @native.Ptr[FILE]) -> FRslt
+
+pub fn fputs(@native.CStr, @native.Ptr[FILE]) -> FRslt
+
+pub fn fread(@native.Ptr[Byte], UInt64, UInt64, @native.Ptr[FILE]) -> UInt64
+
+pub fn fsync(Fd) -> Rslt
+
+pub fn ftruncate(Fd, Int) -> Rslt
+
+pub fn fwrite(@native.ConstPtr[Byte], UInt64, UInt64, @native.Ptr[FILE]) -> UInt64
+
+pub fn get_errno() -> Int
+
+pub fn getcwd(@native.Ptr[Byte], UInt64) -> @native.Ptr[Byte]
+
+pub fn getegid() -> Gid
+
+pub fn geteuid() -> Uid
+
+pub fn getgid() -> Gid
+
+pub fn getgroups(UInt64, @native.Ptr[Gid]) -> Int64
+
+pub fn gethostname(@native.Ptr[Byte], UInt64) -> Rslt
+
+pub fn getpgid(Pid) -> Pid
+
+pub fn getpid() -> Pid
+
+pub fn getppid() -> Pid
+
+pub fn getsid(Pid) -> Sid
+
+pub fn getuid() -> Uid
+
+pub fn isatty(Fd) -> Int
+
+pub fn linkat(Fd, @native.CStr, Fd, @native.CStr, AtFlag) -> Rslt
+
+pub fn lockf(Fd, Int, Int64) -> Rslt
+
+pub fn lseek(Fd, Int64, Whence) -> Int64
+
+pub fn mkdirat(Fd, @native.CStr, Mode) -> Rslt
+
+pub fn nice(Int) -> Rslt
+
+pub let o_accmode : OpenFlag
+
+pub let o_append : OpenFlag
+
+pub let o_cloexec : OpenFlag
+
+pub let o_creat : OpenFlag
+
+pub let o_directory : OpenFlag
+
+pub let o_dsync : OpenFlag
+
+pub let o_excl : OpenFlag
+
+pub let o_exec : OpenFlag
+
+pub let o_nocreat : OpenFlag
+
+pub let o_nofollow : OpenFlag
+
+pub let o_nonblock : OpenFlag
+
+pub let o_rdonly : OpenFlag
+
+pub let o_rdwr : OpenFlag
+
+pub let o_rsync : OpenFlag
+
+pub let o_sync : OpenFlag
+
+pub let o_trunc : OpenFlag
+
+pub let o_wronly : OpenFlag
+
+pub fn openat(Fd, @native.CStr, OpenFlag, Mode) -> Fd
+
+pub fn pause() -> Rslt
+
+pub fn pipe(@native.Ptr[Fd]) -> Rslt
+
+pub fn pread(Fd, @native.Ptr[Byte], UInt64, Int64) -> Rslt
+
+pub fn pwrite(Fd, @native.ConstPtr[Byte], UInt64, Int64) -> Rslt
+
+pub let r_ok : AccessMode
+
+pub fn read(Fd, @native.Ptr[Byte], UInt64) -> Int64
+
+pub let s_ifblk : Mode
+
+pub let s_ifchr : Mode
+
+pub let s_ifdir : Mode
+
+pub let s_ififo : Mode
+
+pub let s_iflnk : Mode
+
+pub let s_ifmt : Mode
+
+pub let s_ifreg : Mode
+
+pub let s_irgrp : Mode
+
+pub let s_iroth : Mode
+
+pub let s_irusr : Mode
+
+pub let s_irwxg : Mode
+
+pub let s_irwxo : Mode
+
+pub let s_irwxu : Mode
+
+pub let s_isgid : Mode
+
+pub let s_issvt : Mode
+
+pub let s_isuid : Mode
+
+pub let s_iwgrp : Mode
+
+pub let s_iwoth : Mode
+
+pub let s_iwusr : Mode
+
+pub let s_ixgrp : Mode
+
+pub let s_ixoth : Mode
+
+pub let s_ixusr : Mode
+
+pub let seek_cur : Whence
+
+pub let seek_end : Whence
+
+pub let seek_set : Whence
+
+pub fn set_errno(Int) -> Unit
+
+pub fn setegid(Gid) -> Rslt
+
+pub fn seteuid(Uid) -> Rslt
+
+pub fn setgid(Gid) -> Rslt
+
+pub fn sethostname(@native.ConstPtr[Byte], UInt64) -> Rslt
+
+pub fn setpgid(Pid, Pid) -> Rslt
+
+pub fn setsid() -> Sid
+
+pub fn setuid(Uid) -> Rslt
+
+pub fn setvbuf(@native.Ptr[FILE], @native.Ptr[Byte], BufMode, UInt64) -> FRslt
+
+pub fn sleep(UInt) -> UInt
+
+pub let stderr_fileno : Fd
+
+pub let stderr_fileptr : @native.Ptr[FILE]
+
+pub let stdin_fileno : Fd
+
+pub let stdin_fileptr : @native.Ptr[FILE]
+
+pub let stdout_fileno : Fd
+
+pub let stdout_fileptr : @native.Ptr[FILE]
+
+pub fn sync() -> Unit
+
+pub fn ttyname_r(Fd, @native.Ptr[Byte], UInt64) -> Rslt
+
+pub fn ungetc(Int, @native.Ptr[FILE]) -> FRslt
+
+pub fn unlinkat(Fd, @native.CStr, Int) -> Rslt
+
+pub let w_ok : AccessMode
+
+pub fn wait(@native.Ptr[Int]) -> Pid
+
+pub fn write(Fd, @native.ConstPtr[Byte], UInt64) -> Int64
+
+pub let x_ok : AccessMode
+
+// Errors
+
+// Types and methods
+type AccessMode
+pub impl Default for AccessMode
+pub impl Eq for AccessMode
+pub impl Show for AccessMode
+
+type AtFlag
+pub impl Default for AtFlag
+pub impl Eq for AtFlag
+pub impl Show for AtFlag
+
+type BufMode
+pub impl Default for BufMode
+pub impl Eq for BufMode
+pub impl Show for BufMode
+
+type DIR
+
+type FILE
+
+type FRslt
+pub fn FRslt::to_char(Self) -> Unit
+pub impl Default for FRslt
+pub impl Eq for FRslt
+pub impl Show for FRslt
+
+type FcntlCmd
+pub impl Default for FcntlCmd
+pub impl Eq for FcntlCmd
+pub impl Show for FcntlCmd
+
+type Fd
+pub impl Default for Fd
+pub impl Eq for Fd
+pub impl Show for Fd
+
+type Gid
+pub fn Gid::unsafe_from_uint(UInt) -> Self
+pub impl Default for Gid
+pub impl Eq for Gid
+pub impl Show for Gid
+
+type Mode
+pub impl BitOr for Mode
+pub impl Default for Mode
+pub impl Eq for Mode
+pub impl Show for Mode
+
+type OpenFlag
+pub impl BitOr for OpenFlag
+pub impl Default for OpenFlag
+pub impl Eq for OpenFlag
+pub impl Show for OpenFlag
+
+type Pid
+pub fn Pid::is_child(Self) -> Bool
+pub fn Pid::is_error(Self) -> Bool
+pub fn Pid::unsafe_from_int(Int) -> Self
+pub impl Default for Pid
+pub impl Eq for Pid
+pub impl Show for Pid
+
+type Rslt
+pub fn Rslt::is_error(Self) -> Bool
+pub fn Rslt::is_success(Self) -> Bool
+pub impl Default for Rslt
+pub impl Eq for Rslt
+pub impl Show for Rslt
+
+type Sid
+pub fn Sid::is_error(Self) -> Bool
+pub fn Sid::unsafe_from_uint(UInt) -> Self
+pub impl Default for Sid
+pub impl Eq for Sid
+pub impl Show for Sid
+
+type Signal
+pub impl Default for Signal
+pub impl Eq for Signal
+pub impl Show for Signal
+
+type Uid
+pub fn Uid::unsafe_from_uint(UInt) -> Self
+pub impl Default for Uid
+pub impl Eq for Uid
+pub impl Show for Uid
+
+type Whence
+pub impl Default for Whence
+pub impl Eq for Whence
+pub impl Show for Whence
+
+// Type aliases
+pub using @native {type CStr}
+
+pub using @native {type ConstPtr}
+
+pub using @native {type Ptr}
+
+pub using @native {type Rc}
+
+// Traits
+

--- a/src/posix/stat.mbt
+++ b/src/posix/stat.mbt
@@ -1,2 +1,3 @@
-///| https://man7.org/linux/man-pages/man2/mkdir.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/mkdir.2.html
 pub extern "c" fn mkdirat(dirfd : Fd, path : CStr, mode : Mode) -> Rslt = "moonbit_posix_mkdirat"

--- a/src/posix/stat.mbt
+++ b/src/posix/stat.mbt
@@ -1,3 +1,4 @@
 ///|
 /// https://man7.org/linux/man-pages/man2/mkdir.2.html
+#borrow(path)
 pub extern "c" fn mkdirat(dirfd : Fd, path : CStr, mode : Mode) -> Rslt = "moonbit_posix_mkdirat"

--- a/src/posix/stdio.mbt
+++ b/src/posix/stdio.mbt
@@ -20,10 +20,12 @@ pub let stdin_fileptr : Ptr[FILE] = _stdin()
 ///|
 pub let stderr_fileptr : Ptr[FILE] = _stderr()
 
-///| https://www.man7.org/linux/man-pages/man3/fputc.3p.html
+///|
+/// https://www.man7.org/linux/man-pages/man3/fputc.3p.html
 pub extern "c" fn fputc(byte : Int, stream : Ptr[FILE]) -> FRslt = "moonbit_posix_fputc"
 
-///| https://man7.org/linux/man-pages/man3/fputs.3p.html
+///|
+/// https://man7.org/linux/man-pages/man3/fputs.3p.html
 pub extern "c" fn fputs(string : CStr, stream : Ptr[FILE]) -> FRslt = "moonbit_posix_fputs"
 
 ///|
@@ -35,17 +37,20 @@ pub let eof : FRslt = _EOF()
 ///|
 pub fn FRslt::to_char(self : FRslt) = "%char_to_int"
 
-///| https://man7.org/linux/man-pages/man3/fgetc.3.html
+///|
+/// https://man7.org/linux/man-pages/man3/fgetc.3.html
 pub extern "c" fn fgetc(stream : Ptr[FILE]) -> FRslt = "moonbit_posix_fgetc"
 
-///| https://man7.org/linux/man-pages/man3/fgets.3p.html
+///|
+/// https://man7.org/linux/man-pages/man3/fgets.3p.html
 pub extern "c" fn fgets(
   s : Ptr[Byte],
   n : Int,
-  stream : Ptr[FILE]
+  stream : Ptr[FILE],
 ) -> Ptr[Byte] = "moonbit_posix_fgets"
 
-///| https://www.man7.org/linux/man-pages/man3/ungetc.3p.html
+///|
+/// https://www.man7.org/linux/man-pages/man3/ungetc.3p.html
 pub extern "c" fn ungetc(ch : Int, stream : Ptr[FILE]) -> FRslt = "moonbit_posix_ungetc"
 
 ///|
@@ -72,35 +77,41 @@ pub let _ionbf : BufMode = __IONBF()
 ///|
 pub let bufsiz : Size = _BUFSIZ()
 
-///| https://man7.org/linux/man-pages/man3/fwrite.3p.html
+///|
+/// https://man7.org/linux/man-pages/man3/fwrite.3p.html
 pub extern "c" fn fwrite(
   ptr : ConstPtr[Byte],
   size : Size,
   n : Size,
-  stream : Ptr[FILE]
+  stream : Ptr[FILE],
 ) -> Size = "moonbit_posix_fwrite"
 
-///| https://man7.org/linux/man-pages/man3/fread.3.html
+///|
+/// https://man7.org/linux/man-pages/man3/fread.3.html
 pub extern "c" fn fread(
   ptr : Ptr[Byte],
   size : Size,
   n : Size,
-  stream : Ptr[FILE]
+  stream : Ptr[FILE],
 ) -> Size = "moonbit_posix_fread"
 
-///| https://man7.org/linux/man-pages/man3/fflush.3.html
+///|
+/// https://man7.org/linux/man-pages/man3/fflush.3.html
 pub extern "c" fn fflush(stream : Ptr[FILE]) -> FRslt = "moonbit_posix_fflush"
 
-///| https://man7.org/linux/man-pages/man3/setvbuf.3p.html
+///|
+/// https://man7.org/linux/man-pages/man3/setvbuf.3p.html
 pub extern "c" fn setvbuf(
   stream : Ptr[FILE],
   buf : Ptr[Byte],
   mode : BufMode,
-  size : Size
+  size : Size,
 ) -> FRslt = "moonbit_posix_setvbuf"
 
-///| https://man7.org/linux/man-pages/man3/fclose.3.html
+///|
+/// https://man7.org/linux/man-pages/man3/fclose.3.html
 pub extern "c" fn fclose(stream : Ptr[FILE]) -> FRslt = "moonbit_posix_fclose"
 
-///| https://man7.org/linux/man-pages/man3/fdopen.3p.html
+///|
+/// https://man7.org/linux/man-pages/man3/fdopen.3p.html
 pub extern "c" fn fdopen(fd : Fd, mode : CStr) -> Ptr[FILE] = "moonbit_posix_fdopen"

--- a/src/posix/stdio.mbt
+++ b/src/posix/stdio.mbt
@@ -22,10 +22,12 @@ pub let stderr_fileptr : Ptr[FILE] = _stderr()
 
 ///|
 /// https://www.man7.org/linux/man-pages/man3/fputc.3p.html
+#borrow(stream)
 pub extern "c" fn fputc(byte : Int, stream : Ptr[FILE]) -> FRslt = "moonbit_posix_fputc"
 
 ///|
 /// https://man7.org/linux/man-pages/man3/fputs.3p.html
+#borrow(string, stream)
 pub extern "c" fn fputs(string : CStr, stream : Ptr[FILE]) -> FRslt = "moonbit_posix_fputs"
 
 ///|
@@ -39,10 +41,12 @@ pub fn FRslt::to_char(self : FRslt) = "%char_to_int"
 
 ///|
 /// https://man7.org/linux/man-pages/man3/fgetc.3.html
+#borrow(stream)
 pub extern "c" fn fgetc(stream : Ptr[FILE]) -> FRslt = "moonbit_posix_fgetc"
 
 ///|
 /// https://man7.org/linux/man-pages/man3/fgets.3p.html
+#borrow(s, stream)
 pub extern "c" fn fgets(
   s : Ptr[Byte],
   n : Int,
@@ -51,6 +55,7 @@ pub extern "c" fn fgets(
 
 ///|
 /// https://www.man7.org/linux/man-pages/man3/ungetc.3p.html
+#borrow(stream)
 pub extern "c" fn ungetc(ch : Int, stream : Ptr[FILE]) -> FRslt = "moonbit_posix_ungetc"
 
 ///|
@@ -79,6 +84,7 @@ pub let bufsiz : Size = _BUFSIZ()
 
 ///|
 /// https://man7.org/linux/man-pages/man3/fwrite.3p.html
+#borrow(ptr, stream)
 pub extern "c" fn fwrite(
   ptr : ConstPtr[Byte],
   size : Size,
@@ -88,6 +94,7 @@ pub extern "c" fn fwrite(
 
 ///|
 /// https://man7.org/linux/man-pages/man3/fread.3.html
+#borrow(ptr, stream)
 pub extern "c" fn fread(
   ptr : Ptr[Byte],
   size : Size,
@@ -97,10 +104,12 @@ pub extern "c" fn fread(
 
 ///|
 /// https://man7.org/linux/man-pages/man3/fflush.3.html
+#borrow(stream)
 pub extern "c" fn fflush(stream : Ptr[FILE]) -> FRslt = "moonbit_posix_fflush"
 
 ///|
 /// https://man7.org/linux/man-pages/man3/setvbuf.3p.html
+#borrow(stream, buf)
 pub extern "c" fn setvbuf(
   stream : Ptr[FILE],
   buf : Ptr[Byte],
@@ -110,8 +119,10 @@ pub extern "c" fn setvbuf(
 
 ///|
 /// https://man7.org/linux/man-pages/man3/fclose.3.html
+#borrow(stream)
 pub extern "c" fn fclose(stream : Ptr[FILE]) -> FRslt = "moonbit_posix_fclose"
 
 ///|
 /// https://man7.org/linux/man-pages/man3/fdopen.3p.html
+#borrow(mode)
 pub extern "c" fn fdopen(fd : Fd, mode : CStr) -> Ptr[FILE] = "moonbit_posix_fdopen"

--- a/src/posix/types.mbt
+++ b/src/posix/types.mbt
@@ -1,8 +1,8 @@
 ///|
-type Fd Int derive(Default, Eq, Show)
+struct Fd(Int) derive(Default, Eq, Show)
 
 ///|
-type Gid UInt derive(Default, Eq, Show)
+struct Gid(UInt) derive(Default, Eq, Show)
 
 ///|
 pub fn Gid::unsafe_from_uint(x : UInt) -> Gid = "%identity"
@@ -14,16 +14,16 @@ pub fn Uid::unsafe_from_uint(x : UInt) -> Uid = "%identity"
 pub fn Sid::unsafe_from_uint(x : UInt) -> Sid = "%identity"
 
 ///|
-type Uid UInt derive(Default, Eq, Show)
+struct Uid(UInt) derive(Default, Eq, Show)
 
 ///|
-type Pid Int derive(Default, Eq, Show)
+struct Pid(Int) derive(Default, Eq, Show)
 
 ///|
 pub fn Pid::unsafe_from_int(x : Int) -> Pid = "%identity"
 
 ///|
-type Sid Int derive(Default, Eq, Show)
+struct Sid(Int) derive(Default, Eq, Show)
 
 ///|
 pub fn Sid::is_error(self : Sid) -> Bool {
@@ -40,10 +40,10 @@ typealias Int64 as Off
 typealias UInt64 as Size
 
 ///|
-type Mode UInt derive(Default, Eq, Show) // TODO
+struct Mode(UInt) derive(Default, Eq, Show) // TODO
 
 ///|
-type Rslt Int derive(Default, Eq, Show)
+struct Rslt(Int) derive(Default, Eq, Show)
 
 ///|
 pub fn Rslt::is_success(x : Rslt) -> Bool {
@@ -56,31 +56,31 @@ pub fn Rslt::is_error(x : Rslt) -> Bool {
 }
 
 ///|
-type FRslt Int derive(Default, Eq, Show)
+struct FRslt(Int) derive(Default, Eq, Show)
 
 ///|
-type Signal Int derive(Default, Eq, Show)
+struct Signal(Int) derive(Default, Eq, Show)
 
 ///|
 typealias Int as Errno
 
 ///|
-type AtFlag Int derive(Default, Eq, Show)
+struct AtFlag(Int) derive(Default, Eq, Show)
 
 ///|
-type OpenFlag Int derive(Default, Eq, Show)
+struct OpenFlag(Int) derive(Default, Eq, Show)
 
 ///|
-type Whence Int derive(Default, Eq, Show)
+struct Whence(Int) derive(Default, Eq, Show)
 
 ///|
-type FcntlCmd Int derive(Default, Eq, Show)
+struct FcntlCmd(Int) derive(Default, Eq, Show)
 
 ///|
-type BufMode Int derive(Default, Eq, Show)
+struct BufMode(Int) derive(Default, Eq, Show)
 
 ///|
-type AccessMode Int derive(Default, Eq, Show)
+struct AccessMode(Int) derive(Default, Eq, Show)
 
 ///|
 pub fn Pid::is_child(self : Pid) -> Bool {

--- a/src/posix/types.mbt
+++ b/src/posix/types.mbt
@@ -27,17 +27,17 @@ struct Sid(Int) derive(Default, Eq, Show)
 
 ///|
 pub fn Sid::is_error(self : Sid) -> Bool {
-  self.inner() == -1
+  self.0 == -1
 }
 
 ///|
-typealias Int64 as OptSize
+type OptSize = Int64
 
 ///|
-typealias Int64 as Off
+type Off = Int64
 
 ///|
-typealias UInt64 as Size
+type Size = UInt64
 
 ///|
 struct Mode(UInt) derive(Default, Eq, Show) // TODO
@@ -47,12 +47,12 @@ struct Rslt(Int) derive(Default, Eq, Show)
 
 ///|
 pub fn Rslt::is_success(x : Rslt) -> Bool {
-  x.inner() == 0
+  x.0 == 0
 }
 
 ///|
 pub fn Rslt::is_error(x : Rslt) -> Bool {
-  x.inner() == -1
+  x.0 == -1
 }
 
 ///|
@@ -62,7 +62,7 @@ struct FRslt(Int) derive(Default, Eq, Show)
 struct Signal(Int) derive(Default, Eq, Show)
 
 ///|
-typealias Int as Errno
+type Errno = Int
 
 ///|
 struct AtFlag(Int) derive(Default, Eq, Show)
@@ -84,10 +84,10 @@ struct AccessMode(Int) derive(Default, Eq, Show)
 
 ///|
 pub fn Pid::is_child(self : Pid) -> Bool {
-  self.inner() == 0
+  self.0 == 0
 }
 
 ///|
 pub fn Pid::is_error(self : Pid) -> Bool {
-  self.inner() == -1
+  self.0 == -1
 }

--- a/src/posix/unistd.mbt
+++ b/src/posix/unistd.mbt
@@ -1,32 +1,43 @@
-///| https://man7.org/linux/man-pages/man3/getcwd.3.html
+///|
+/// https://man7.org/linux/man-pages/man3/getcwd.3.html
 pub extern "c" fn getcwd(buf : Ptr[Byte], size : Size) -> Ptr[Byte] = "moonbit_posix_getcwd"
 
-///| https://man7.org/linux/man-pages/man2/fork.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/fork.2.html
 pub extern "c" fn fork() -> Pid = "moonbit_posix_fork"
 
-///| https://man7.org/linux/man-pages/man2/gethostname.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/gethostname.2.html
 pub extern "c" fn gethostname(buf : Ptr[Byte], size : Size) -> Rslt = "moonbit_posix_gethostname"
 
-///| https://man7.org/linux/man-pages/man2/sethostname.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/sethostname.2.html
 pub extern "c" fn sethostname(name : ConstPtr[Byte], len : Size) -> Rslt = "moonbit_posix_sethostname"
 
-///| https://man7.org/linux/man-pages/man2/getgroups.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/getgroups.2.html
 pub extern "c" fn getgroups(size : Size, buf : Ptr[Gid]) -> OptSize = "moonbit_posix_getgroups"
 
-///| https://man7.org/linux/man-pages/man2/nice.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/nice.2.html
 pub extern "c" fn nice(inc : Int) -> Rslt = "moonbit_posix_nice"
 
-///| https://man7.org/linux/man-pages/man2/pause.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/pause.2.html
 pub extern "c" fn pause() -> Rslt = "moonbit_posix_pause"
 
-///| https://man7.org/linux/man-pages/man3/sleep.3.html
+///|
+/// https://man7.org/linux/man-pages/man3/sleep.3.html
 pub extern "c" fn sleep(seconds : UInt) -> UInt = "moonbit_posix_sleep"
 
-///| https://man7.org/linux/man-pages/man2/sync.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/sync.2.html
 pub extern "c" fn sync() = "moonbit_posix_sync"
 
-///| https://man7.org/linux/man-pages/man3/confstr.3.html
+///|
+/// https://man7.org/linux/man-pages/man3/confstr.3.html
 pub extern "c" fn confstr(name : Int, buf : Ptr[Byte], size : Size) -> Size = "moonbit_posix_confstr"
 
-///| https://man7.org/linux/man-pages/man3/ttyname_r.3.html
+///|
+/// https://man7.org/linux/man-pages/man3/ttyname_r.3.html
 pub extern "c" fn ttyname_r(fd : Fd, buf : Ptr[Byte], size : Size) -> Rslt = "moonbit_posix_ttyname_r"

--- a/src/posix/unistd.mbt
+++ b/src/posix/unistd.mbt
@@ -1,5 +1,6 @@
 ///|
 /// https://man7.org/linux/man-pages/man3/getcwd.3.html
+#borrow(buf)
 pub extern "c" fn getcwd(buf : Ptr[Byte], size : Size) -> Ptr[Byte] = "moonbit_posix_getcwd"
 
 ///|
@@ -8,14 +9,17 @@ pub extern "c" fn fork() -> Pid = "moonbit_posix_fork"
 
 ///|
 /// https://man7.org/linux/man-pages/man2/gethostname.2.html
+#borrow(buf)
 pub extern "c" fn gethostname(buf : Ptr[Byte], size : Size) -> Rslt = "moonbit_posix_gethostname"
 
 ///|
 /// https://man7.org/linux/man-pages/man2/sethostname.2.html
+#borrow(name)
 pub extern "c" fn sethostname(name : ConstPtr[Byte], len : Size) -> Rslt = "moonbit_posix_sethostname"
 
 ///|
 /// https://man7.org/linux/man-pages/man2/getgroups.2.html
+#borrow(buf)
 pub extern "c" fn getgroups(size : Size, buf : Ptr[Gid]) -> OptSize = "moonbit_posix_getgroups"
 
 ///|
@@ -36,8 +40,10 @@ pub extern "c" fn sync() = "moonbit_posix_sync"
 
 ///|
 /// https://man7.org/linux/man-pages/man3/confstr.3.html
+#borrow(buf)
 pub extern "c" fn confstr(name : Int, buf : Ptr[Byte], size : Size) -> Size = "moonbit_posix_confstr"
 
 ///|
 /// https://man7.org/linux/man-pages/man3/ttyname_r.3.html
+#borrow(buf)
 pub extern "c" fn ttyname_r(fd : Fd, buf : Ptr[Byte], size : Size) -> Rslt = "moonbit_posix_ttyname_r"

--- a/src/posix/unistd_at.mbt
+++ b/src/posix/unistd_at.mbt
@@ -1,28 +1,32 @@
-///| https://man7.org/linux/man-pages/man3/access.3p.html
+///|
+/// https://man7.org/linux/man-pages/man3/access.3p.html
 pub extern "c" fn faccessat(
   dirfd : Fd,
   path : CStr,
   amode : AccessMode,
-  flag : AtFlag
+  flag : AtFlag,
 ) -> Rslt = "moonbit_posix_faccessat"
 
-///| https://man7.org/linux/man-pages/man2/unlink.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/unlink.2.html
 pub extern "c" fn unlinkat(dirfd : Fd, path : CStr, flags : Int) -> Rslt = "moonbit_posix_unlinkat"
 
-///| https://man7.org/linux/man-pages/man3/chown.3p.html
+///|
+/// https://man7.org/linux/man-pages/man3/chown.3p.html
 pub extern "c" fn fchownat(
   dirfd : Fd,
   path : CStr,
   owner : Uid,
   group : Gid,
-  flags : AtFlag
+  flags : AtFlag,
 ) -> Rslt = "moonbit_posix_fchownat"
 
-///| https://man7.org/linux/man-pages/man2/link.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/link.2.html
 pub extern "c" fn linkat(
   olddirfd : Fd,
   oldpath : CStr,
   newdirfd : Fd,
   newpath : CStr,
-  flags : AtFlag
+  flags : AtFlag,
 ) -> Rslt = "moonbit_posix_linkat"

--- a/src/posix/unistd_at.mbt
+++ b/src/posix/unistd_at.mbt
@@ -1,5 +1,6 @@
 ///|
 /// https://man7.org/linux/man-pages/man3/access.3p.html
+#borrow(path)
 pub extern "c" fn faccessat(
   dirfd : Fd,
   path : CStr,
@@ -9,10 +10,12 @@ pub extern "c" fn faccessat(
 
 ///|
 /// https://man7.org/linux/man-pages/man2/unlink.2.html
+#borrow(path)
 pub extern "c" fn unlinkat(dirfd : Fd, path : CStr, flags : Int) -> Rslt = "moonbit_posix_unlinkat"
 
 ///|
 /// https://man7.org/linux/man-pages/man3/chown.3p.html
+#borrow(path)
 pub extern "c" fn fchownat(
   dirfd : Fd,
   path : CStr,
@@ -23,6 +26,7 @@ pub extern "c" fn fchownat(
 
 ///|
 /// https://man7.org/linux/man-pages/man2/link.2.html
+#borrow(oldpath, newpath)
 pub extern "c" fn linkat(
   olddirfd : Fd,
   oldpath : CStr,

--- a/src/posix/unistd_fd.mbt
+++ b/src/posix/unistd_fd.mbt
@@ -1,16 +1,21 @@
-///| https://man7.org/linux/man-pages/man2/close.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/close.2.html
 pub extern "c" fn close(fd : Fd) -> Rslt = "moonbit_posix_close"
 
-///| https://man7.org/linux/man-pages/man2/read.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/read.2.html
 pub extern "c" fn read(fd : Fd, buf : Ptr[Byte], count : Size) -> OptSize = "moonbit_posix_read"
 
-///| https://man7.org/linux/man-pages/man2/write.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/write.2.html
 pub extern "c" fn write(fd : Fd, buf : ConstPtr[Byte], count : Size) -> OptSize = "moonbit_posix_write"
 
-///| https://man7.org/linux/man-pages/man2/dup.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/dup.2.html
 pub extern "c" fn dup(fd : Fd) -> Fd = "moonbit_posix_dup"
 
-///| https://man7.org/linux/man-pages/man2/dup.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/dup.2.html
 pub extern "c" fn dup2(oldfd : Fd, newfd : Fd) -> Fd = "moonbit_posix_dup2"
 
 ///|
@@ -31,20 +36,24 @@ pub let stdout_fileno : Fd = _STDOUT_FILENO()
 ///|
 pub let stderr_fileno : Fd = _STDERR_FILENO()
 
-///| https://man7.org/linux/man-pages/man3/fchdir.3p.html
+///|
+/// https://man7.org/linux/man-pages/man3/fchdir.3p.html
 pub extern "c" fn fchdir(fd : Fd) -> Rslt = "moonbit_posix_fchdir"
 
-///| https://man7.org/linux/man-pages/man3/fchown.3p.html
+///|
+/// https://man7.org/linux/man-pages/man3/fchown.3p.html
 pub extern "c" fn fchown(fd : Fd, owner : Uid, group : Gid) -> Rslt = "moonbit_posix_fchown"
 
-///| https://man7.org/linux/man-pages/man2/fsync.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/fsync.2.html
 pub extern "c" fn fdatasync(fd : Fd) -> Rslt = "moonbit_posix_fdatasync"
 
-///| https://man7.org/linux/man-pages/man2/execve.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/execve.2.html
 pub extern "c" fn fexecve(
   fd : Fd,
   argv : ConstPtr[CStr],
-  envp : ConstPtr[CStr]
+  envp : ConstPtr[CStr],
 ) -> Rslt = "moonbit_posix_fexecve"
 
 ///|
@@ -52,40 +61,47 @@ pub extern "c" fn fexecve(
 ///  https://www.gnu.org/software/libc/manual/html_node/Pathconf.html
 pub extern "c" fn fpathconf(fd : Fd, name : Int) -> OptSize = "moonbit_posix_fpathconf"
 
-///| https://man7.org/linux/man-pages/man2/fsync.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/fsync.2.html
 pub extern "c" fn fsync(fd : Fd) -> Rslt = "moonbit_posix_fsync"
 
-///| https://man7.org/linux/man-pages/man3/ftruncate.3p.html
+///|
+/// https://man7.org/linux/man-pages/man3/ftruncate.3p.html
 pub extern "c" fn ftruncate(fd : Fd, length : Int) -> Rslt = "moonbit_posix_ftruncate"
 
-///| // https://man7.org/linux/man-pages/man3/lockf.3.html
+///|
+/// // https://man7.org/linux/man-pages/man3/lockf.3.html
 pub extern "c" fn lockf(fd : Fd, cmd : Int, len : OptSize) -> Rslt = "moonbit_posix_lockf"
 
-///| https://man7.org/linux/man-pages/man3/isatty.3.html
+///|
+/// https://man7.org/linux/man-pages/man3/isatty.3.html
 pub extern "c" fn isatty(fd : Fd) -> Int = "moonbit_posix_isatty"
 
-///| https://man7.org/linux/man-pages/man2/lseek.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/lseek.2.html
 pub extern "c" fn lseek(fd : Fd, offset : Off, whence : Whence) -> Off = "moonbit_posix_lseek"
 
-///| 
+///|
 /// https://man7.org/linux/man-pages/man7/pipe.7.html
 /// https://man7.org/linux/man-pages/man2/pipe.2.html
 pub extern "c" fn pipe(fds : Ptr[Fd]) -> Rslt = "moonbit_posix_pipe"
 
-///| https://man7.org/linux/man-pages/man2/pread.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/pread.2.html
 pub extern "c" fn pread(
   fd : Fd,
   buf : Ptr[Byte],
   count : Size,
-  offset : Off
+  offset : Off,
 ) -> Rslt = "moonbit_posix_pread"
 
-///| https://www.man7.org/linux/man-pages/man3/pwrite.3p.html
+///|
+/// https://www.man7.org/linux/man-pages/man3/pwrite.3p.html
 pub extern "c" fn pwrite(
   fd : Fd,
   buf : ConstPtr[Byte],
   count : Size,
-  offset : Off
+  offset : Off,
 ) -> Rslt = "moonbit_posix_pwrite"
 
 ///|

--- a/src/posix/unistd_fd.mbt
+++ b/src/posix/unistd_fd.mbt
@@ -4,10 +4,12 @@ pub extern "c" fn close(fd : Fd) -> Rslt = "moonbit_posix_close"
 
 ///|
 /// https://man7.org/linux/man-pages/man2/read.2.html
+#borrow(buf)
 pub extern "c" fn read(fd : Fd, buf : Ptr[Byte], count : Size) -> OptSize = "moonbit_posix_read"
 
 ///|
 /// https://man7.org/linux/man-pages/man2/write.2.html
+#borrow(buf)
 pub extern "c" fn write(fd : Fd, buf : ConstPtr[Byte], count : Size) -> OptSize = "moonbit_posix_write"
 
 ///|
@@ -50,6 +52,7 @@ pub extern "c" fn fdatasync(fd : Fd) -> Rslt = "moonbit_posix_fdatasync"
 
 ///|
 /// https://man7.org/linux/man-pages/man2/execve.2.html
+#borrow(argv, envp)
 pub extern "c" fn fexecve(
   fd : Fd,
   argv : ConstPtr[CStr],
@@ -84,10 +87,12 @@ pub extern "c" fn lseek(fd : Fd, offset : Off, whence : Whence) -> Off = "moonbi
 ///|
 /// https://man7.org/linux/man-pages/man7/pipe.7.html
 /// https://man7.org/linux/man-pages/man2/pipe.2.html
+#borrow(fds)
 pub extern "c" fn pipe(fds : Ptr[Fd]) -> Rslt = "moonbit_posix_pipe"
 
 ///|
 /// https://man7.org/linux/man-pages/man2/pread.2.html
+#borrow(buf)
 pub extern "c" fn pread(
   fd : Fd,
   buf : Ptr[Byte],
@@ -97,6 +102,7 @@ pub extern "c" fn pread(
 
 ///|
 /// https://www.man7.org/linux/man-pages/man3/pwrite.3p.html
+#borrow(buf)
 pub extern "c" fn pwrite(
   fd : Fd,
   buf : ConstPtr[Byte],

--- a/src/posix/unistd_id.mbt
+++ b/src/posix/unistd_id.mbt
@@ -1,51 +1,65 @@
 // groups id
 
-///| https://man7.org/linux/man-pages/man2/getgid.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/getgid.2.html
 pub extern "c" fn getgid() -> Gid = "moonbit_posix_getgid"
 
-///| https://man7.org/linux/man-pages/man2/setgid.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/setgid.2.html
 pub extern "c" fn setgid(gid : Gid) -> Rslt = "moonbit_posix_setgid"
 
-///| https://man7.org/linux/man-pages/man2/getegid.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/getegid.2.html
 pub extern "c" fn getegid() -> Gid = "moonbit_posix_getegid"
 
-///| https://man7.org/linux/man-pages/man2/setegid.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/setegid.2.html
 pub extern "c" fn setegid(gid : Gid) -> Rslt = "moonbit_posix_setegid"
 
 // user id
 
-///| https://man7.org/linux/man-pages/man2/getuid.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/getuid.2.html
 pub extern "c" fn getuid() -> Uid = "moonbit_posix_getuid"
 
-///| https://man7.org/linux/man-pages/man2/geteuid.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/geteuid.2.html
 pub extern "c" fn geteuid() -> Uid = "moonbit_posix_geteuid"
 
-///| https://man7.org/linux/man-pages/man2/setuid.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/setuid.2.html
 pub extern "c" fn setuid(uid : Uid) -> Rslt = "moonbit_posix_setuid"
 
-///| https://man7.org/linux/man-pages/man2/seteuid.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/seteuid.2.html
 pub extern "c" fn seteuid(uid : Uid) -> Rslt = "moonbit_posix_seteuid"
 
 // process groups id
 
-///| https://man7.org/linux/man-pages/man3/setpgid.3p.html
+///|
+/// https://man7.org/linux/man-pages/man3/setpgid.3p.html
 pub extern "c" fn setpgid(pid : Pid, pgid : Pid) -> Rslt = "moonbit_posix_setpgid"
 
-///| https://man7.org/linux/man-pages/man3/getpgid.3p.html
+///|
+/// https://man7.org/linux/man-pages/man3/getpgid.3p.html
 pub extern "c" fn getpgid(pid : Pid) -> Pid = "moonbit_posix_getpgid"
 
 // session id
 
-///| https://man7.org/linux/man-pages/man2/getsid.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/getsid.2.html
 pub extern "c" fn getsid(pid : Pid) -> Sid = "moonbit_posix_getsid"
 
-///| https://man7.org/linux/man-pages/man2/setsid.2.html
+///|
+/// https://man7.org/linux/man-pages/man2/setsid.2.html
 pub extern "c" fn setsid() -> Sid = "moonbit_posix_setsid"
 
 // process id
 
-///| https://man7.org/linux/man-pages/man3/getpid.3p.html
+///|
+/// https://man7.org/linux/man-pages/man3/getpid.3p.html
 pub extern "c" fn getpid() -> Pid = "moonbit_posix_getpid"
 
-///| https://man7.org/linux/man-pages/man3/getppid.3p.html
+///|
+/// https://man7.org/linux/man-pages/man3/getppid.3p.html
 pub extern "c" fn getppid() -> Pid = "moonbit_posix_getppid"

--- a/src/posix/wait.mbt
+++ b/src/posix/wait.mbt
@@ -1,4 +1,5 @@
 // https://man7.org/linux/man-pages/man2/wait.2.html
 
 ///|
+#borrow(wstatus)
 pub extern "c" fn wait(wstatus : Ptr[Int]) -> Pid = "moonbit_posix_wait"


### PR DESCRIPTION
- Summary
- Renamed deprecated Iter/Iter2 usages to Iterator/Iterator2 patterns in POSIX modules and examples
- Added/updated generated `.mbti` interfaces across examples and `src/posix`
- Updated `.gitignore` to include `target` and `_build`

- Why
- Reduce deprecated warnings/errors and align with current MoonBit API changes, especially the Iter/Iterator migration
- Prepare the repository for upcoming build artifact locations

- Implementation details
- New Iterator/Iterator2 constructors follow the callback-based `Some/None` pattern; legacy helpers delegate to new iterator functions where applicable
- Regenerated interfaces reflect updated public surface from the deprecation fixes